### PR TITLE
Attempt to fix the known empty commit issue, and also for commit messages that contain double quotes.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,5 +84,5 @@ runs:
         git config --local user.email "${{ inputs.author_email }}"
         git config --local user.name "${{ inputs.author_name }}"
         git add -A
-        git commit -m "${{ inputs.commit_message }}"
+        git commit -m --allow-empty '${{ inputs.commit_message }}'
         git push https://${GITHUB_ACTOR}:${{ inputs.deployment_repository_token }}@github.com/${{ inputs.deployment_repository }}.git


### PR DESCRIPTION
This should handle double quotes, but I am unsure what it will do with single quotes in the message.

Also, it handles the known issue when the commit hash is the same because of a rebuild (and there is nothing to commit, but it should trigger the deployment action).