### PR TITLE
throw away doble quotes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -82,7 +82,7 @@ runs:
       with:
           source: ${{ inputs.commit_message }}
           find: '"'        
-          replace: '\"' 
+          replace: '' 
 
     - name: Commit changes
       shell: bash


### PR DESCRIPTION
Apparently escaping doesn't work,  so let's try just to replace them with nothing.